### PR TITLE
Update zapr.gemspec

### DIFF
--- a/zapr.gemspec
+++ b/zapr.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "owasp_zap", "0.0.5"
+  spec.add_dependency "owasp_zap", "0.0.95"
   spec.add_dependency "clamp"
   spec.add_dependency "colorize"
   spec.add_dependency "terminal-table"


### PR DESCRIPTION
Update owasp_zap dependency version due to OWASP ZAP update. The old version of OWASP ZAP isn't available from sourceforge anymore. The newer versions, post 2.4.1, use an API key that is troublesome in an automated process like this. We need a version of the owasp_zap gem that disables the API key.
